### PR TITLE
bugfix: visualizer not working the first time loaded

### DIFF
--- a/src/components/visualizer/index.tsx
+++ b/src/components/visualizer/index.tsx
@@ -9,7 +9,7 @@ export default function AudioVisualizer() {
     useContext(WebAudioContext);
   const { isPlaying, imgUrl } = useContext(MusicContext);
   const rafRef = useRef<number>();
-  let lastTime: number;
+  let lastTime: number | null;
   const POINT_NUM = 64;
   const OFFSET = 10;
   const RECT_WIDTH = 4;
@@ -36,9 +36,11 @@ export default function AudioVisualizer() {
     const progress = timestamp - lastTime;
     if (progress === 0 || progress > 0) {
       try {
-        analyserNode?.getByteFrequencyData(visualArr!);
-        setAudioData(Array.from(visualArr!));
-        lastTime = timestamp;
+        if (analyserNode && visualArr) {
+          analyserNode.getByteFrequencyData(visualArr);
+          setAudioData(Array.from(visualArr));
+          lastTime = timestamp;
+        }
       } catch (err) {
         console.log(err);
       }
@@ -124,20 +126,14 @@ export default function AudioVisualizer() {
     canvasRef.current = newCanvas;
   };
 
-  const initVisualArr = () => {
-    if (analyserNode) {
-      const newVisualArr = new Uint8Array(analyserNode.frequencyBinCount);
-      setVisualArr(newVisualArr);
-    }
-  };
-
   const cleanVisualArr = () => {
-    setVisualArr(new Uint8Array());
+    if (analyserNode) setVisualArr(new Uint8Array(analyserNode.frequencyBinCount));
+    else setVisualArr(new Uint8Array());
+    rafRef.current && cancelAnimationFrame(rafRef.current);
   };
 
   useEffect(() => {
     initCanvas();
-    initVisualArr();
     return () => {
       cleanVisualArr();
     };

--- a/src/contexts/WebAudioContext.tsx
+++ b/src/contexts/WebAudioContext.tsx
@@ -53,6 +53,7 @@ export const WebAudioContextProvider = ({ children }: Props) => {
     analyserNodeRef.current.fftSize = FFT_SIZE;
     gainNodeRef.current.connect(audioContextRef.current.destination);
     setAudioSource(audioContextRef.current.createBufferSource());
+    setVisualArr(new Uint8Array(analyserNodeRef.current.frequencyBinCount));
     setIsInitialized(true);
     return () => {
       if (audioContextRef.current) {


### PR DESCRIPTION
### Descriptions
The visualizer now works correctly when you load it for the first time by modifying the hooks logic.
Modify the clean function when you close the visualizer. Cancel the animation frame every time when closing the visualizer.

- Link to UI design (if possible):

### Provide screenshots or videos that the function is working.

### Provide screenshots of no warning, or error in the console.

- [x] All unit tests passing and coverage of testing is more than 90% unless special needs.
- [x] No merge conflict with the `main` branch, make sure your code is up to date with `main`.
- [x] Check PR title is aligned with your ticket.
- [x] Check your app will run without crashes.
- [x] Check if there are hard-coded values.
- [x] No `//eslint-disable-next-line no-unused-vars`, unless otherwise specified.
- [x] Check you are using `camelCase && PascalCase` correctly.
- [x] Remove unused comments.
