### PR TITLE
fix: change onClick event to onMouseEnter on album to trigger next li…

### DIFF
--- a/src/components/AlbumItem.tsx
+++ b/src/components/AlbumItem.tsx
@@ -29,7 +29,7 @@ export default function AlbumItem({ musicList }: AlbumItemProps) {
       setIsPlaying((prev) => !prev);
     }
   };
-  const handleAlbumClick = () => {
+  const handleAlbumEnter = () => {
     setSelectedAlbum(musicList);
   };
 
@@ -37,7 +37,11 @@ export default function AlbumItem({ musicList }: AlbumItemProps) {
     <div className="relative cursor-pointer text-center text-light">
       {musicList && (
         <>
-          <Link href={`/album/${musicList?.id}`} className="relative" onClick={handleAlbumClick}>
+          <Link
+            href={`/album/${musicList?.id}`}
+            className="relative"
+            onMouseEnter={handleAlbumEnter}
+          >
             <figure>
               <img
                 className="rounded-full"


### PR DESCRIPTION
### Descriptions
fix the issue that next/link on album is not pre-fetching

### Provide screenshots or videos that the function is working.

https://github.com/taodemy/taotify/assets/25715518/c9c0bb68-81a6-43df-859f-c56fe86f831d

- [ ✅ ] All unit tests passing and coverage of testing is more than 90% unless special needs.
- [ ✅ ] No merge conflict with the `main` branch, make sure your code is up to date with `main`.
- [ ✅ ] Check PR title is aligned with your ticket.
- [ ✅ ] Check your app will run without crashes.
- [ ✅ ] Check if there are hard-coded values.
- [ ✅ ] No `//eslint-disable-next-line no-unused-vars`, unless otherwise specified.
- [ ✅ ] Check you are using `camelCase && PascalCase` correctly.
- [ ✅ ] Remove unused comments.
